### PR TITLE
Minor update to tests

### DIFF
--- a/bert_deid/model.py
+++ b/bert_deid/model.py
@@ -220,6 +220,10 @@ class BertForDEID(BertForNER):
 
     def annotate(self, text, annotations=None, document_id=None, column=None,
                  **kwargs):
+
+        # sets the model to evaluation mode to fix parameters
+        self.eval()
+
         device = (torch.device("cuda")
                   if next(self.parameters()).is_cuda
                   else "cpu")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pandas==0.24.2
 sympy==1.4
 # modelling
 torch==1.1.0
-pytorch-pretrained-bert==0.6.2
+pytorch-pretrained-bert==0.6.1
 # testing
 pytest==4.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ from bert_deid import model as bert_deid_model
 
 @pytest.fixture(scope="session")
 def config_radiology_reports():
+    """
+    Load configuration file for the test radiology dataset.
+    """
     # get path of conftest.py
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -30,6 +33,9 @@ def config_radiology_reports():
 
 @pytest.fixture(scope="session")
 def radiology_reports(config_radiology_reports):
+    """
+    Load the test radiology reports.
+    """
     text_path = config_radiology_reports['text_path']
 
     reports_list = os.listdir(text_path)
@@ -50,6 +56,9 @@ def radiology_reports(config_radiology_reports):
 
 @pytest.fixture(scope="session")
 def bert_i2b2_2014_model():
+    """
+    Load the model.
+    """
     return bert_deid_model.BertForDEID(
-        model_dir="models/i2b2_2014"
+        model_dir="tests/models/i2b2_2014/"
     )

--- a/tests/models/i2b2_2014/README.md
+++ b/tests/models/i2b2_2014/README.md
@@ -1,0 +1,7 @@
+# Running the tests with Pytest
+
+To run the tests, upload the pretrained model `pytorch_model.bin` to this folder.
+
+## The model should match the following MD5 hash
+
+MD5 (pytorch_model.bin) = 503e6eee66a4799da9d623142e7bc8ae

--- a/tests/models/i2b2_2014/config.json
+++ b/tests/models/i2b2_2014/config.json
@@ -1,0 +1,13 @@
+{
+  "attention_probs_dropout_prob": 0.1,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.1,
+  "hidden_size": 768,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "max_position_embeddings": 512,
+  "num_attention_heads": 12,
+  "num_hidden_layers": 12,
+  "type_vocab_size": 2,
+  "vocab_size": 28996
+}

--- a/tests/test_bert_deid.py
+++ b/tests/test_bert_deid.py
@@ -4,19 +4,63 @@ import pytest
 from pydeid import annotation
 
 
-def test_bert_deid_rr(radiology_reports, bert_i2b2_2014_model):
-    for f in radiology_reports:
+def test_output_of_pretrained_bert_on_rad_reports(radiology_reports,
+                                                  bert_i2b2_2014_model):
+    """
+    Test to ensure that the pre-trained model returns annotations for the
+    sample radiology reports.
+    """
+    cols = ['document_id', 'annotation_id', 'annotator', 'start', 'stop',
+            'entity', 'entity_type', 'comment', 'confidence']
+
+    # if the model is not run in eval() mode, output will differ on each run
+    expected_rows = [69, 39, 45, 66, 51, 49]
+
+    for f, n_rows in zip(radiology_reports, expected_rows):
         text = radiology_reports[f]
 
         # ann with bert
-        ann = bert_i2b2_2014_model.annotate(
-            text, document_id=f)
+        ann = bert_i2b2_2014_model.annotate(text, document_id=f)
+
+        # are the column headers as expected?
+        assert (cols == ann.columns).all()
+
+        # are there annotations?
+        assert ann.shape[0] > 0
+
+        # are there the expected number of annotations?
+        assert len(ann) == n_rows
+
+
+def test_output_of_pretrained_bert_on_rad_reports_with_merge(radiology_reports,
+                                                             bert_i2b2_2014_model):
+    """
+    Test to ensure that the pre-trained model returns annotations for the
+    sample radiology reports after intervals are merged.
+    """
+    cols = ['document_id', 'annotation_id', 'annotator', 'start', 'stop',
+            'entity', 'entity_type', 'comment', 'confidence']
+
+    # if the model is not run in eval() mode, output will differ on each run
+    expected_rows = [22, 14, 13, 19, 18, 16]
+
+    for f, n_rows in zip(radiology_reports, expected_rows):
+        text = radiology_reports[f]
+
+        # ann with bert
+        ann = bert_i2b2_2014_model.annotate(text, document_id=f)
 
         # merge intervals that are close together
-        ann = annotation.merge_intervals(
-            ann, dist=1, text=text)
+        ann = annotation.merge_intervals(ann, dist=1, text=text)
 
         # post-fix to reduce false positives
         ann = bert_i2b2_2014_model.postfix(ann, text)
 
+        # are the column headers as expected?
+        assert (cols == ann.columns).all()
+
+        # are there annotations?
         assert ann.shape[0] > 0
+
+        # are there the expected number of annotations?
+        assert len(ann) == n_rows


### PR DESCRIPTION
Minor updates:

- set annotate to use evaluation mode
- switches back to pytorch-pretrained-bert==0.6.1 for now
- moves the trained model folder to /tests 
- adds a couple of assertions to the tests (check number of rows are as expected)