### PR TITLE
Test and training fails with 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pandas==0.24.2
 sympy==1.4
 # modelling
 torch==1.1.0
-pytorch-pretrained-bert==0.6.1
+pytorch-pretrained-bert==0.6.2
 # testing
 pytest==4.2.0


### PR DESCRIPTION
This just bumps the requirement for pytorch_pretrained_bert back to 0.6.2 (it looks like I downgraded to 0.6.1 previously, though I'm not clear why). Both `train_bert.py` and `pytest` fail on 0.6.1.

```
python train_bert.py --data_path ../data/binary/i2b2_2014 --model_path ../tmp  --bert_model bert-large-cased --task_name i2b2 --max_seq_length=128 --do_train --train_batch_size 32 --num_train_epochs 3 --warmup_proportion=0.4 --seed 7802;

Traceback (most recent call last):
  File "train_bert.py", line 40, in <module>
    from pytorch_pretrained_bert.optimization import BertAdam, WarmupLinearSchedule
ImportError: cannot import name 'WarmupLinearSchedule' from 'pytorch_pretrained_bert.optimization' (/home/tpollard/miniconda3/envs/tpml/lib/python3.7/site-packages/pytorch_pretrained_bert/optimization.py)
```

I'll follow up shortly with a request to move from pytorch_pretrained_bert to pytorch_transformers